### PR TITLE
serialisation feature breaks compilation

### DIFF
--- a/crates/rerecast/Cargo.toml
+++ b/crates/rerecast/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { workspace = true }
 
 [features]
 default = []
-serialize = ["dep:serde", "glam/serde", "slotmap/serde"]
+serialize = ["dep:serde", "glam/serde", "slotmap/serde", "bitflags/serde"]
 bevy_reflect = ["dep:bevy_reflect"]
 
 [lints]


### PR DESCRIPTION
enable `bitflags/serde` when feature `serialize` is enabled