### PR TITLE
fix: avian rerecast version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,11 +474,35 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avian3d"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82608b43397affac139547dfa9beb3208034c53e1a3cfe5d4079db1af362104"
+dependencies = [
+ "approx",
+ "avian_derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bevy",
+ "bevy_heavy",
+ "bevy_math",
+ "bevy_transform_interpolation",
+ "bitflags 2.10.0",
+ "derive_more",
+ "disqualified",
+ "glam_matrix_extras",
+ "itertools 0.13.0",
+ "nalgebra",
+ "parry3d",
+ "slab",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "avian3d"
 version = "0.6.0-dev"
 source = "git+https://github.com/avianphysics/avian#cbc9a2144ba75da3169fbc8a48e5283fe7f805a2"
 dependencies = [
  "approx",
- "avian_derive",
+ "avian_derive 0.2.2 (git+https://github.com/avianphysics/avian)",
  "bevy",
  "bevy_heavy",
  "bevy_math",
@@ -498,6 +522,18 @@ dependencies = [
 [[package]]
 name = "avian_derive"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b257f601a1535e0d4a7a7796f535e3a13de62fd422b16dff7c14d27f0d4048"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "avian_derive"
+version = "0.2.2"
 source = "git+https://github.com/avianphysics/avian#cbc9a2144ba75da3169fbc8a48e5283fe7f805a2"
 dependencies = [
  "proc-macro-error2",
@@ -508,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "avian_rerecast"
-version = "0.5.0-dev"
+version = "0.4.0"
 dependencies = [
- "avian3d",
+ "avian3d 0.5.0",
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
@@ -1867,7 +1903,7 @@ name = "bevy_trenchbroom_avian"
 version = "0.13.0-dev"
 source = "git+https://github.com/janhohenheim/bevy_trenchbroom?branch=avian-0.6#dd52cf42f8b02800605f6c08ab0ea635b46103c8"
 dependencies = [
- "avian3d",
+ "avian3d 0.6.0-dev",
  "bevy",
  "bevy_trenchbroom",
 ]
@@ -5342,7 +5378,7 @@ dependencies = [
 name = "rerecast_examples"
 version = "0.1.0"
 dependencies = [
- "avian3d",
+ "avian3d 0.5.0",
  "avian_rerecast",
  "bevy",
  "bevy_rerecast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-development"]
 readme = "readme.md"
 
 [workspace.dependencies]
-avian3d = { version = "0.6.0-dev", default-features = false, git = "https://github.com/avianphysics/avian" }
+avian3d = { version = "0.5.0", default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_json = { version = "1", default-features = false, features = [
     "alloc",
@@ -63,7 +63,7 @@ rerecast = { version = "0.3", path = "crates/rerecast", default-features = false
 bevy_rerecast = { version = "0.4", path = "crates/bevy_rerecast", default-features = false }
 bevy_rerecast_core = { version = "0.4", path = "crates/bevy_rerecast_core", default-features = false }
 bevy_rerecast_editor_integration = { version = "0.4", path = "crates/bevy_rerecast_editor_integration", default-features = false }
-avian_rerecast = { version = "0.5.0-dev", path = "crates/avian_rerecast", default-features = false }
+avian_rerecast = { version = "0.4.0", path = "crates/avian_rerecast", default-features = false }
 test_utils = { version = "0.1", path = "crates/test_utils", default-features = false }
 
 # Other stuffs

--- a/crates/avian_rerecast/Cargo.toml
+++ b/crates/avian_rerecast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avian_rerecast"
 description = "Avian backend for bevy_rerecast"
-version = "0.5.0-dev"
+version = "0.4.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
Hi, while upgrading to bevy 0.18 I've noticed avian_rerecast has invalid versions specified and publishing to crates.io fails.

Maybe you did this on purpose, but I did it anyways just in case (: