### PR TITLE
Add `bevy_rapier3d`-based backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
  "glam_matrix_extras",
  "itertools 0.14.0",
  "obvhs",
- "parry3d",
+ "parry3d 0.26.0",
  "smallvec",
  "thiserror 2.0.18",
  "thread_local",
@@ -1419,6 +1419,19 @@ name = "bevy_ptr"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f98cbc6d34bbdb58240b72ed1731931b4991a893b3a3238bb7c42ae054aa676"
+
+[[package]]
+name = "bevy_rapier3d"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea1aada7322af63b68f5697c08b04bf916348e7f748ece298417fd13968215a1"
+dependencies = [
+ "bevy",
+ "bitflags 2.11.0",
+ "log",
+ "nalgebra",
+ "rapier3d",
+]
 
 [[package]]
 name = "bevy_reflect"
@@ -3448,6 +3461,141 @@ dependencies = [
 
 [[package]]
 name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
 version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
@@ -3467,6 +3615,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
 dependencies = [
  "bytemuck",
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -4244,6 +4402,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,6 +4518,51 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "unicode-ident",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+dependencies = [
+ "approx",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4490,6 +4703,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,6 +4730,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4969,6 +5212,34 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99471b7b6870f7fe406d5611dd4b4c9b07aa3e5436b1d27e1515f9832bb0c6b"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.11.0",
+ "downcast-rs 2.0.2",
+ "either",
+ "ena",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
+ "log",
+ "nalgebra",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "rstar",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "static_assertions",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "parry3d"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e04d21bda5249438b5695e7f08f1655524a6025bcdb186c324b7a66562f2d61"
@@ -5258,6 +5529,19 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pxfm"
@@ -5356,10 +5640,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "rapier3d"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68073fdc88f6b709002767ce8deffffb05ac06824bf9f98a23e270bcea64ba9f"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "downcast-rs 2.0.2",
+ "log",
+ "nalgebra",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "parry3d 0.25.3",
+ "profiling",
+ "rustc-hash 2.1.1",
+ "simba",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "wide",
+]
+
+[[package]]
+name = "rapier_rerecast"
+version = "0.5.0-rc.3"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_math",
+ "bevy_rapier3d",
+ "bevy_reflect",
+ "bevy_rerecast_core",
+ "bevy_transform",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -6543,6 +6871,12 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typewit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5836,9 +5836,11 @@ dependencies = [
  "avian3d",
  "avian_rerecast",
  "bevy",
+ "bevy_rapier3d",
  "bevy_rerecast",
  "bevy_trenchbroom",
  "bevy_trenchbroom_avian",
+ "rapier_rerecast",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "readme.md"
 
 [workspace.dependencies]
 avian3d = { version = "0.6.0-rc.1", default-features = false }
+bevy_rapier3d = { version = "0.33.0", default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_json = { version = "1", default-features = false, features = [
     "alloc",
@@ -64,6 +65,7 @@ bevy_rerecast = { version = "0.4", path = "crates/bevy_rerecast", default-featur
 bevy_rerecast_core = { version = "0.4", path = "crates/bevy_rerecast_core", default-features = false }
 bevy_rerecast_editor_integration = { version = "0.4", path = "crates/bevy_rerecast_editor_integration", default-features = false }
 avian_rerecast = { version = "0.5.0-rc.1", path = "crates/avian_rerecast", default-features = false }
+rapier_rerecast = { version = "0.5.0-rc.1", path = "crates/rapier_rerecast", default-features = false }
 test_utils = { version = "0.1", path = "crates/test_utils", default-features = false }
 
 # Other stuffs

--- a/crates/rapier_rerecast/Cargo.toml
+++ b/crates/rapier_rerecast/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "rapier_rerecast"
+description = "Rapier backend for bevy_rerecast"
+version = "0.5.0-rc.3"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
+readme = { workspace = true }
+
+[dependencies]
+bevy_app = { workspace = true }
+bevy_ecs = { workspace = true }
+bevy_math = { workspace = true }
+bevy_reflect = { workspace = true }
+bevy_transform = { workspace = true }
+bevy_rapier3d = { workspace = true, features = ["dim3"] }
+bevy_rerecast_core = { workspace = true, features = ["std"] }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]
+all-features = true

--- a/crates/rapier_rerecast/src/collider_to_trimesh.rs
+++ b/crates/rapier_rerecast/src/collider_to_trimesh.rs
@@ -47,7 +47,10 @@ impl ColliderToTriMesh for Collider {
         subdivisions: u32,
     ) -> Option<TriMesh> {
         shape_to_trimesh(
-            &self.as_typed_shape().as_typed_shape(),
+            &self
+                .as_typed_shape()
+                .raw_scale_by(Vec3::splat(0.5), subdivisions)?
+                .as_typed_shape(),
             pos.into(),
             rot.into(),
             subdivisions,
@@ -107,7 +110,7 @@ fn shape_to_trimesh(
     Some(TriMesh {
         vertices: vertices
             .into_iter()
-            .map(|v| pos + Vec3A::from(rot.mul_vec3(v.into())))
+            .map(|v| pos + rot.mul_vec3a(v.into()))
             .collect(),
         indices: indices.into_iter().map(|i| i.into()).collect(),
         area_types: vec![AreaType::NOT_WALKABLE; indices_len],

--- a/crates/rapier_rerecast/src/collider_to_trimesh.rs
+++ b/crates/rapier_rerecast/src/collider_to_trimesh.rs
@@ -24,17 +24,17 @@ pub trait ColliderToTriMesh {
     /// A [`TriMesh`] if the collider is supported, otherwise `None`
     ///
     /// The following shapes are not supported:
-    /// - [`Segment`](avian3d::parry::shape::Segment)
-    /// - [`Polyline`](avian3d::parry::shape::Polyline)
-    /// - [`HalfSpace`](avian3d::parry::shape::HalfSpace)
+    /// - [`Segment`](bevy_rapier3d::parry::shape::Segment)
+    /// - [`Polyline`](bevy_rapier3d::parry::shape::Polyline)
+    /// - [`HalfSpace`](bevy_rapier3d::parry::shape::HalfSpace)
     /// - Custom shapes
     ///
     /// The following rounded shapes are supported, but only the inner shape without rounding is used:
-    /// - [`RoundCuboid`](avian3d::parry::shape::RoundCuboid)
-    /// - [`RoundTriangle`](avian3d::parry::shape::RoundTriangle)
-    /// - [`RoundConvexPolyhedron`](avian3d::parry::shape::RoundConvexPolyhedron)
-    /// - [`RoundCylinder`](avian3d::parry::shape::RoundCylinder)
-    /// - [`RoundCone`](avian3d::parry::shape::RoundCone)
+    /// - [`RoundCuboid`](bevy_rapier3d::parry::shape::RoundCuboid)
+    /// - [`RoundTriangle`](bevy_rapier3d::parry::shape::RoundTriangle)
+    /// - [`RoundConvexPolyhedron`](bevy_rapier3d::parry::shape::RoundConvexPolyhedron)
+    /// - [`RoundCylinder`](bevy_rapier3d::parry::shape::RoundCylinder)
+    /// - [`RoundCone`](bevy_rapier3d::parry::shape::RoundCone)
     fn to_trimesh(
         &self,
         pos: impl Into<Vec3>,

--- a/crates/rapier_rerecast/src/collider_to_trimesh.rs
+++ b/crates/rapier_rerecast/src/collider_to_trimesh.rs
@@ -3,7 +3,11 @@
 use bevy_math::{Quat, Vec3, Vec3A};
 use bevy_rapier3d::{
     geometry::Collider,
-    parry::shape::{Compound, TypedShape},
+    na::Isometry,
+    parry::{
+        shape::{Compound, TypedShape},
+        transformation::utils,
+    },
 };
 use bevy_rerecast_core::rerecast::{AreaType, TriMesh};
 
@@ -47,13 +51,11 @@ impl ColliderToTriMesh for Collider {
         subdivisions: u32,
     ) -> Option<TriMesh> {
         shape_to_trimesh(
-            &self
-                .as_typed_shape()
-                .raw_scale_by(Vec3::splat(0.5), subdivisions)?
-                .as_typed_shape(),
+            &self.as_unscaled_typed_shape().as_typed_shape(),
             pos.into(),
             rot.into(),
             subdivisions,
+            self.scale(),
         )
     }
 }
@@ -63,6 +65,7 @@ fn shape_to_trimesh(
     pos: Vec3,
     rot: Quat,
     subdivisions: u32,
+    scale: Vec3,
 ) -> Option<TriMesh> {
     let (vertices, indices) = match shape {
         // Simple cases
@@ -84,7 +87,7 @@ fn shape_to_trimesh(
         TypedShape::Cone(cone) => cone.to_trimesh(subdivisions),
         // Compounds need to be unpacked
         TypedShape::Compound(compound) => {
-            return Some(compound_trimesh(compound, pos, rot, subdivisions));
+            return Some(compound_trimesh(compound, pos, rot, subdivisions, scale));
         }
         // Rounded shapes ignore the rounding and use the inner shape
         TypedShape::RoundCuboid(round_shape) => round_shape.inner_shape.to_trimesh(),
@@ -105,19 +108,24 @@ fn shape_to_trimesh(
         TypedShape::HalfSpace(_half_space) => return None,
         TypedShape::Custom(_shape) => return None,
     };
+    let mut vertices = utils::scaled(vertices, scale.into());
+    utils::transform(&mut vertices, Isometry::from_parts(pos.into(), rot.into()));
+
     let indices_len = indices.len();
-    let pos = Vec3A::from(pos);
     Some(TriMesh {
-        vertices: vertices
-            .into_iter()
-            .map(|v| pos + rot.mul_vec3a(v.into()))
-            .collect(),
+        vertices: vertices.into_iter().map(Vec3A::from).collect(),
         indices: indices.into_iter().map(|i| i.into()).collect(),
         area_types: vec![AreaType::NOT_WALKABLE; indices_len],
     })
 }
 
-fn compound_trimesh(compound: &Compound, pos: Vec3, rot: Quat, subdivisions: u32) -> TriMesh {
+fn compound_trimesh(
+    compound: &Compound,
+    pos: Vec3,
+    rot: Quat,
+    subdivisions: u32,
+    scale: Vec3,
+) -> TriMesh {
     compound.shapes().iter().fold(
         TriMesh::default(),
         |mut compound_trimesh, (sub_pos, shape)| {
@@ -125,7 +133,7 @@ fn compound_trimesh(compound: &Compound, pos: Vec3, rot: Quat, subdivisions: u32
             let rot = rot.mul_quat(sub_pos.rotation.into()).normalize();
             let Some(trimesh) =
                 // No need to track recursive compounds because parry panics on nested compounds anyways lol
-                shape_to_trimesh(&shape.as_typed_shape(), pos, rot,  subdivisions)
+                shape_to_trimesh(&shape.as_typed_shape(), pos, rot, subdivisions, scale)
             else {
                 return compound_trimesh;
             };
@@ -139,13 +147,184 @@ fn compound_trimesh(compound: &Compound, pos: Vec3, rot: Quat, subdivisions: u32
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy_math::{Quat, Vec3};
+    use bevy_rerecast_core::rerecast::Aabb3d;
+
+    const TEST_SCALE: f32 = 2.5;
+
+    #[inline]
+    fn get_typed_shape(collider: &Collider) -> TypedShape<'_> {
+        collider.as_unscaled_typed_shape().as_typed_shape()
+    }
+
+    #[inline]
+    fn create_trimesh_and_get_aabb(collider: &Collider) -> (TriMesh, Aabb3d) {
+        let shape = get_typed_shape(collider);
+        let trimesh = shape_to_trimesh(
+            &shape,
+            Vec3::ZERO,
+            Quat::IDENTITY,
+            16,
+            Vec3::splat(TEST_SCALE),
+        )
+        .unwrap();
+        let aabb = trimesh.compute_aabb().unwrap();
+        (trimesh, aabb)
+    }
+
+    #[inline]
+    fn test_aabb(name: &str, aabb: Aabb3d, expect_x: f32, expect_y: f32, expect_z: f32) {
+        let got_x = aabb.max.x - aabb.min.x;
+        let got_y = aabb.max.y - aabb.min.y;
+        let got_z = aabb.max.z - aabb.min.z;
+
+        assert!(
+            (got_x - expect_x).abs() < f32::EPSILON,
+            "{name} X should be ~{expect_x}, got {got_x}",
+        );
+        assert!(
+            (got_y - expect_y).abs() < f32::EPSILON,
+            "{name} Y should be ~{expect_y}, got {got_y}",
+        );
+        assert!(
+            (got_z - expect_z).abs() < f32::EPSILON,
+            "{name} Z should be ~{expect_z}, got {got_z}",
+        );
+    }
+
+    #[inline]
+    fn test_collider(name: &str, collider: Collider, expect_x: f32, expect_y: f32, expect_z: f32) {
+        let (trimesh, aabb) = create_trimesh_and_get_aabb(&collider);
+        println!("{trimesh:?}");
+        println!("{aabb:?}");
+        test_aabb(name, aabb, expect_x, expect_y, expect_z);
+    }
+
+    #[test]
+    fn cuboid_aabb_size() {
+        test_collider("Cuboid", Collider::cuboid(1.0, 2.0, 3.0), 5.0, 10.0, 15.0);
+    }
+
+    #[test]
+    fn ball_aabb_size() {
+        test_collider("Ball", Collider::ball(2.0), 10.0, 10.0, 10.0);
+    }
+
+    #[test]
+    fn capsule_aabb_size() {
+        test_collider("CapsuleY", Collider::capsule_y(2.0, 0.5), 2.5, 12.5, 2.5);
+    }
+
+    #[test]
+    fn cylinder_aabb_size() {
+        test_collider("Cylinder", Collider::cylinder(1.0, 0.5), 2.5, 5.0, 2.5);
+    }
+
+    #[test]
+    fn cone_aabb_size() {
+        test_collider("Cone", Collider::cone(1.0, 0.5), 2.5, 5.0, 2.5);
+    }
+
+    #[test]
+    fn triangle_aabb_size() {
+        let collider = Collider::triangle(
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+        );
+        test_collider("Triangle", collider, 2.5, 2.5, 0.0);
+    }
+
+    #[test]
+    fn trimesh_aabb_size() {
+        let vertices = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+        ];
+        let indices = vec![[0, 1, 2]];
+        let collider = Collider::trimesh(vertices, indices).unwrap();
+        test_collider("Trimesh", collider, 2.5, 2.5, 0.0);
+    }
+
+    #[test]
+    fn heightfield_aabb_size() {
+        let heights = vec![1.0, 2.0, 1.0, 0.0];
+        let collider = Collider::heightfield(heights, 2, 2, Vec3::ONE);
+        test_collider("Heightfield", collider, 2.5, 5.0, 2.5);
+    }
+
+    #[test]
+    fn convex_polyhedron_aabb_size() {
+        let vertices = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+        ];
+        let indices = vec![[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]];
+        let collider = Collider::convex_mesh(vertices, &indices).unwrap();
+        test_collider("ConvexPolyhedron", collider, 2.5, 2.5, 2.5);
+    }
+
+    #[test]
+    fn round_cuboid_aabb_size() {
+        let collider = Collider::round_cuboid(0.5, 1.0, 1.5, 0.2);
+        test_collider("RoundCuboid", collider, 2.5, 5.0, 7.5);
+    }
+
+    #[test]
+    fn round_cylinder_aabb_size() {
+        let collider = Collider::round_cylinder(1.0, 0.5, 0.1);
+        test_collider("RoundCylinder", collider, 2.5, 5.0, 2.5);
+    }
+
+    #[test]
+    fn round_cone_aabb_size() {
+        let collider = Collider::round_cone(1.0, 0.5, 0.1);
+        test_collider("RoundCone", collider, 2.5, 5.0, 2.5);
+    }
+
+    #[test]
+    fn round_triangle_aabb_size() {
+        let collider = Collider::round_triangle(
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            0.1,
+        );
+        test_collider("RoundTriangle", collider, 2.5, 2.5, 0.0);
+    }
+
+    #[test]
+    fn round_convex_polyhedron_aabb_size() {
+        let vertices = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+        ];
+        let indices = vec![[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]];
+        let collider = Collider::round_convex_mesh(vertices, &indices, 0.1).unwrap();
+        test_collider("RoundConvexPolyhedron", collider, 2.5, 2.5, 2.5);
+    }
+
+    #[test]
+    fn compound_collider_aabb_size() {
+        let cuboid = Collider::cuboid(1.0, 2.0, 3.0);
+        let ball = Collider::ball(2.0);
+        let collider = Collider::compound(vec![
+            (Vec3::new(-10.0, 0.0, 5.0), Quat::IDENTITY, cuboid),
+            (Vec3::new(0.0, -10.0, -5.0), Quat::IDENTITY, ball),
+        ]);
+        test_collider("Compound", collider, 17.5, 20.0, 22.5);
+    }
 
     #[test]
     fn rasterizes_cuboid() {
         let collider = Collider::cuboid(1.0, 2.0, 3.0);
-        let trimesh = collider
-            .to_trimesh(Vec3::default(), bevy_math::Quat::default(), 1)
-            .unwrap();
+        let shape = get_typed_shape(&collider);
+        let trimesh = shape_to_trimesh(&shape, Vec3::ZERO, Quat::IDENTITY, 1, Vec3::ONE).unwrap();
         assert_eq!(trimesh.vertices.len(), 8);
         assert_eq!(trimesh.indices.len(), 12);
     }

--- a/crates/rapier_rerecast/src/collider_to_trimesh.rs
+++ b/crates/rapier_rerecast/src/collider_to_trimesh.rs
@@ -1,0 +1,149 @@
+//! Contains traits and methods for converting [`Collider`]s into trimeshes.
+
+use bevy_math::{Quat, Vec3, Vec3A};
+use bevy_rapier3d::{
+    geometry::Collider,
+    parry::shape::{Compound, TypedShape},
+};
+use bevy_rerecast_core::rerecast::{AreaType, TriMesh};
+
+/// Convenience trait that allows a [`Collider`] to be converted into a [`TriMesh`].
+pub trait ColliderToTriMesh {
+    /// Converts the collider into a [`TriMesh`].
+    ///
+    /// # Arguments
+    ///
+    /// * `subdivisions` - The number of subdivisions to use for the collider. This is used for curved shapes such as circles and spheres.
+    ///
+    /// # Returns
+    ///
+    /// A [`TriMesh`] if the collider is supported, otherwise `None`
+    ///
+    /// The following shapes are not supported:
+    /// - [`Segment`](avian3d::parry::shape::Segment)
+    /// - [`Polyline`](avian3d::parry::shape::Polyline)
+    /// - [`HalfSpace`](avian3d::parry::shape::HalfSpace)
+    /// - Custom shapes
+    ///
+    /// The following rounded shapes are supported, but only the inner shape without rounding is used:
+    /// - [`RoundCuboid`](avian3d::parry::shape::RoundCuboid)
+    /// - [`RoundTriangle`](avian3d::parry::shape::RoundTriangle)
+    /// - [`RoundConvexPolyhedron`](avian3d::parry::shape::RoundConvexPolyhedron)
+    /// - [`RoundCylinder`](avian3d::parry::shape::RoundCylinder)
+    /// - [`RoundCone`](avian3d::parry::shape::RoundCone)
+    fn to_trimesh(
+        &self,
+        pos: impl Into<Vec3>,
+        rot: impl Into<Quat>,
+        subdivisions: u32,
+    ) -> Option<TriMesh>;
+}
+
+impl ColliderToTriMesh for Collider {
+    fn to_trimesh(
+        &self,
+        pos: impl Into<Vec3>,
+        rot: impl Into<Quat>,
+        subdivisions: u32,
+    ) -> Option<TriMesh> {
+        shape_to_trimesh(
+            &self.as_typed_shape().as_typed_shape(),
+            pos.into(),
+            rot.into(),
+            subdivisions,
+        )
+    }
+}
+
+fn shape_to_trimesh(
+    shape: &TypedShape,
+    pos: Vec3,
+    rot: Quat,
+    subdivisions: u32,
+) -> Option<TriMesh> {
+    let (vertices, indices) = match shape {
+        // Simple cases
+        TypedShape::Cuboid(cuboid) => cuboid.to_trimesh(),
+        TypedShape::Voxels(voxels) => voxels.to_trimesh(),
+        TypedShape::ConvexPolyhedron(convex_polyhedron) => convex_polyhedron.to_trimesh(),
+        TypedShape::HeightField(height_field) => height_field.to_trimesh(),
+        // Triangles
+        TypedShape::Triangle(triangle) => {
+            (vec![triangle.a, triangle.b, triangle.c], vec![[0, 1, 2]])
+        }
+        TypedShape::TriMesh(tri_mesh) => {
+            (tri_mesh.vertices().to_vec(), tri_mesh.indices().to_vec())
+        }
+        // Need subdivisions
+        TypedShape::Ball(ball) => ball.to_trimesh(subdivisions, subdivisions),
+        TypedShape::Capsule(capsule) => capsule.to_trimesh(subdivisions, subdivisions),
+        TypedShape::Cylinder(cylinder) => cylinder.to_trimesh(subdivisions),
+        TypedShape::Cone(cone) => cone.to_trimesh(subdivisions),
+        // Compounds need to be unpacked
+        TypedShape::Compound(compound) => {
+            return Some(compound_trimesh(compound, pos, rot, subdivisions));
+        }
+        // Rounded shapes ignore the rounding and use the inner shape
+        TypedShape::RoundCuboid(round_shape) => round_shape.inner_shape.to_trimesh(),
+        TypedShape::RoundTriangle(round_shape) => (
+            vec![
+                round_shape.inner_shape.a,
+                round_shape.inner_shape.b,
+                round_shape.inner_shape.c,
+            ],
+            vec![[0, 1, 2]],
+        ),
+        TypedShape::RoundConvexPolyhedron(round_shape) => round_shape.inner_shape.to_trimesh(),
+        TypedShape::RoundCylinder(round_shape) => round_shape.inner_shape.to_trimesh(subdivisions),
+        TypedShape::RoundCone(round_shape) => round_shape.inner_shape.to_trimesh(subdivisions),
+        // Not supported
+        TypedShape::Segment(_segment) => return None,
+        TypedShape::Polyline(_polyline) => return None,
+        TypedShape::HalfSpace(_half_space) => return None,
+        TypedShape::Custom(_shape) => return None,
+    };
+    let indices_len = indices.len();
+    let pos = Vec3A::from(pos);
+    Some(TriMesh {
+        vertices: vertices
+            .into_iter()
+            .map(|v| pos + Vec3A::from(rot.mul_vec3(v.into())))
+            .collect(),
+        indices: indices.into_iter().map(|i| i.into()).collect(),
+        area_types: vec![AreaType::NOT_WALKABLE; indices_len],
+    })
+}
+
+fn compound_trimesh(compound: &Compound, pos: Vec3, rot: Quat, subdivisions: u32) -> TriMesh {
+    compound.shapes().iter().fold(
+        TriMesh::default(),
+        |mut compound_trimesh, (sub_pos, shape)| {
+            let pos = pos + rot.mul_vec3(sub_pos.translation.into());
+            let rot = rot.mul_quat(sub_pos.rotation.into()).normalize();
+            let Some(trimesh) =
+                // No need to track recursive compounds because parry panics on nested compounds anyways lol
+                shape_to_trimesh(&shape.as_typed_shape(), pos, rot,  subdivisions)
+            else {
+                return compound_trimesh;
+            };
+
+            compound_trimesh.extend(trimesh);
+            compound_trimesh
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rasterizes_cuboid() {
+        let collider = Collider::cuboid(1.0, 2.0, 3.0);
+        let trimesh = collider
+            .to_trimesh(Vec3::default(), bevy_math::Quat::default(), 1)
+            .unwrap();
+        assert_eq!(trimesh.vertices.len(), 8);
+        assert_eq!(trimesh.indices.len(), 12);
+    }
+}

--- a/crates/rapier_rerecast/src/lib.rs
+++ b/crates/rapier_rerecast/src/lib.rs
@@ -1,0 +1,64 @@
+//! Backend for using [`bevy_rapier3d`](https://docs.rs/bevy_rapier3d) with [`bevy_rerecast`](https://docs.rs/bevy_rerecast).
+
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_rapier3d::prelude::*;
+use bevy_reflect::prelude::*;
+use bevy_rerecast_core::{NavmeshApp as _, NavmeshSettings, rerecast::TriMesh};
+use bevy_transform::prelude::*;
+
+mod collider_to_trimesh;
+pub use crate::collider_to_trimesh::ColliderToTriMesh;
+
+/// Everything you need to get started with the Navmesh plugin.
+pub mod prelude {
+    pub use crate::{ExcludeColliderFromNavmesh, RapierBackendPlugin};
+}
+
+/// The plugin of the crate. Will make all entities with [`Collider`] a collider belonging to a static [`RigidBody`] available for navmesh generation.
+#[non_exhaustive]
+#[derive(Debug, Default)]
+pub struct RapierBackendPlugin;
+
+impl Plugin for RapierBackendPlugin {
+    fn build(&self, app: &mut App) {
+        app.set_navmesh_backend(collider_backend);
+    }
+}
+
+/// Component to opt-out a [`Collider`] or [`RigidBody`] from navmesh generation when using [`RapierBackendPlugin`].
+/// If that backend is not used, this component has no effect.
+#[derive(Debug, Default, Component, Reflect)]
+#[reflect(Component)]
+pub struct ExcludeColliderFromNavmesh;
+
+fn collider_backend(
+    input: In<NavmeshSettings>,
+    colliders: Query<
+        (Entity, &Collider, &GlobalTransform, &RigidBody),
+        Without<ExcludeColliderFromNavmesh>,
+    >,
+) -> TriMesh {
+    colliders
+        .iter()
+        .filter_map(|(entity, collider, transform, body)| {
+            if input
+                .filter
+                .as_ref()
+                .is_some_and(|entities| !entities.contains(&entity))
+            {
+                return None;
+            }
+            if *body != RigidBody::Fixed {
+                return None;
+            }
+            let subdivisions = 10;
+            let pos = transform.translation();
+            let rot = transform.rotation();
+            collider.to_trimesh(pos, rot, subdivisions)
+        })
+        .fold(TriMesh::default(), |mut acc, t| {
+            acc.extend(t);
+            acc
+        })
+}

--- a/crates/rapier_rerecast/src/lib.rs
+++ b/crates/rapier_rerecast/src/lib.rs
@@ -35,7 +35,10 @@ pub struct ExcludeColliderFromNavmesh;
 fn collider_backend(
     input: In<NavmeshSettings>,
     colliders: Query<(Entity, &Collider, &GlobalTransform), Without<ExcludeColliderFromNavmesh>>,
-    bodies: Query<AnyOf<(&RigidBody, &ChildOf)>, Without<ExcludeColliderFromNavmesh>>,
+    bodies: Query<(
+        AnyOf<(&RigidBody, &ChildOf)>,
+        Has<ExcludeColliderFromNavmesh>,
+    )>,
 ) -> TriMesh {
     colliders
         .iter()
@@ -49,8 +52,8 @@ fn collider_backend(
             }
 
             let mut body_entity = entity;
-            while let Ok((body, child_of)) = bodies.get(body_entity) {
-                if body.is_some_and(|body| *body != RigidBody::Fixed) {
+            while let Ok(((body, child_of), is_excluded)) = bodies.get(body_entity) {
+                if body.is_some_and(|body| *body != RigidBody::Fixed || is_excluded) {
                     return None;
                 }
                 if let Some(&ChildOf(parent)) = child_of {
@@ -68,4 +71,100 @@ fn collider_backend(
             acc.extend(t);
             acc
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_math::Vec3A;
+    use bevy_rerecast_core::{NavmeshBackend, NavmeshSettings};
+
+    #[test]
+    fn exclude_collider_from_navmesh() {
+        use bevy_transform::TransformPlugin;
+
+        let mut app = App::new();
+        app.add_plugins((TransformPlugin, RapierBackendPlugin));
+
+        let _included_body = app
+            .world_mut()
+            .spawn((
+                Collider::cuboid(1.0, 1.0, 1.0),
+                RigidBody::Fixed,
+                Transform::from_xyz(0.0, 0.0, 10.0),
+            ))
+            .id();
+
+        let _excluded_body = app
+            .world_mut()
+            .spawn((
+                Collider::cuboid(1.0, 1.0, 1.0),
+                RigidBody::Fixed,
+                Transform::from_xyz(10.0, 0.0, 0.0),
+                ExcludeColliderFromNavmesh,
+            ))
+            .id();
+
+        let body_with_child = app
+            .world_mut()
+            .spawn((
+                RigidBody::Fixed,
+                Transform::from_xyz(0.0, 0.0, -10.0),
+                ExcludeColliderFromNavmesh,
+            ))
+            .id();
+
+        let _included_child = app
+            .world_mut()
+            .spawn((
+                Collider::cuboid(1.0, 1.0, 1.0),
+                Transform::from_xyz(-10.0, 0.0, 0.0),
+                ChildOf(body_with_child),
+            ))
+            .id();
+
+        app.update();
+        app.update();
+
+        let settings = NavmeshSettings::default();
+        let backend_id = app.world().resource::<NavmeshBackend>().0;
+        let trimesh: TriMesh = app
+            .world_mut()
+            .run_system_with(backend_id, settings.clone())
+            .unwrap();
+
+        let included_vertices = trimesh.vertices.len();
+        assert!(included_vertices > 0, "The navmesh should have vertices");
+        assert_eq!(
+            included_vertices, 8,
+            "Should have exactly 1 cubes worth of vertices (1 x 8)"
+        );
+
+        let has_included_body = trimesh
+            .vertices
+            .iter()
+            .any(|v| v.distance(Vec3A::new(0.0, 0.0, 10.0)) <= 1.0);
+        assert!(
+            has_included_body,
+            "Included body at (0, 0, 10) should be in navmesh"
+        );
+
+        let has_excluded_body = trimesh
+            .vertices
+            .iter()
+            .any(|v| v.distance(Vec3A::new(10.0, 0.0, 0.0)) <= 1.0);
+        assert!(
+            !has_excluded_body,
+            "Excluded body at (10, 0, 0) should NOT be in navmesh"
+        );
+
+        let has_excluded_child = trimesh
+            .vertices
+            .iter()
+            .any(|v| v.distance(Vec3A::new(-10.0, 0.0, -10.0)) <= 1.0);
+        assert!(
+            !has_excluded_child,
+            "Excluded child at (-10, 0, -10) should NOT be in navmesh"
+        );
+    }
 }

--- a/crates/rapier_rerecast/src/lib.rs
+++ b/crates/rapier_rerecast/src/lib.rs
@@ -63,7 +63,7 @@ fn collider_backend(
                 break;
             }
 
-            let subdivisions = 10;
+            let subdivisions = 16;
             let (_scale, rot, pos) = transform.to_scale_rotation_translation();
             collider.to_trimesh(pos, rot, subdivisions)
         })
@@ -89,7 +89,7 @@ mod tests {
         let _included_body = app
             .world_mut()
             .spawn((
-                Collider::cuboid(1.0, 1.0, 1.0),
+                Collider::cuboid(0.1, 0.1, 0.1),
                 RigidBody::Fixed,
                 Transform::from_xyz(0.0, 0.0, 10.0),
             ))
@@ -98,7 +98,7 @@ mod tests {
         let _excluded_body = app
             .world_mut()
             .spawn((
-                Collider::cuboid(1.0, 1.0, 1.0),
+                Collider::cuboid(0.1, 0.1, 0.1),
                 RigidBody::Fixed,
                 Transform::from_xyz(10.0, 0.0, 0.0),
                 ExcludeColliderFromNavmesh,
@@ -117,7 +117,7 @@ mod tests {
         let _included_child = app
             .world_mut()
             .spawn((
-                Collider::cuboid(1.0, 1.0, 1.0),
+                Collider::cuboid(0.1, 0.1, 0.1),
                 Transform::from_xyz(-10.0, 0.0, 0.0),
                 ChildOf(body_with_child),
             ))

--- a/crates/rapier_rerecast/src/lib.rs
+++ b/crates/rapier_rerecast/src/lib.rs
@@ -34,14 +34,12 @@ pub struct ExcludeColliderFromNavmesh;
 
 fn collider_backend(
     input: In<NavmeshSettings>,
-    colliders: Query<
-        (Entity, &Collider, &GlobalTransform, &RigidBody),
-        Without<ExcludeColliderFromNavmesh>,
-    >,
+    colliders: Query<(Entity, &Collider, &GlobalTransform), Without<ExcludeColliderFromNavmesh>>,
+    bodies: Query<AnyOf<(&RigidBody, &ChildOf)>, Without<ExcludeColliderFromNavmesh>>,
 ) -> TriMesh {
     colliders
         .iter()
-        .filter_map(|(entity, collider, transform, body)| {
+        .filter_map(|(entity, collider, transform)| {
             if input
                 .filter
                 .as_ref()
@@ -49,12 +47,21 @@ fn collider_backend(
             {
                 return None;
             }
-            if *body != RigidBody::Fixed {
-                return None;
+
+            let mut body_entity = entity;
+            while let Ok((body, child_of)) = bodies.get(body_entity) {
+                if body.is_some_and(|body| *body != RigidBody::Fixed) {
+                    return None;
+                }
+                if let Some(&ChildOf(parent)) = child_of {
+                    body_entity = parent;
+                    continue;
+                }
+                break;
             }
+
             let subdivisions = 10;
-            let pos = transform.translation();
-            let rot = transform.rotation();
+            let (_scale, rot, pos) = transform.to_scale_rotation_translation();
             collider.to_trimesh(pos, rot, subdivisions)
         })
         .fold(TriMesh::default(), |mut acc, t| {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,9 +14,11 @@ readme = { workspace = true }
 [dependencies]
 bevy_rerecast = { workspace = true, default-features = true }
 avian_rerecast = { workspace = true }
+rapier_rerecast = { workspace = true }
 bevy = { workspace = true, features = ["bevy_remote"] }
 bevy_trenchbroom = { workspace = true }
 avian3d = { workspace = true, features = ["parry-f32"] }
+bevy_rapier3d = { workspace = true }
 bevy_trenchbroom_avian = { workspace = true }
 
 [lints]

--- a/examples/examples/from_avian_collider.rs
+++ b/examples/examples/from_avian_collider.rs
@@ -84,7 +84,7 @@ fn setup(
     ));
 
     commands.spawn((
-        Text::new("Press space to generate navmesh"),
+        Text::new("Press space to generate navmesh from avian colliders"),
         Node {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),

--- a/examples/examples/from_avian_collider.rs
+++ b/examples/examples/from_avian_collider.rs
@@ -35,42 +35,47 @@ fn setup(
 ) {
     let material_gray = materials.add(Color::from(tailwind::GRAY_300));
     let material_red = materials.add(Color::from(tailwind::RED_500));
-    let shape = Cuboid::new(50.0, 0.1, 50.0);
+
     commands.spawn((
         Name::new("Ground"),
-        Mesh3d(meshes.add(shape)),
         RigidBody::Static,
-        Collider::from(shape),
-        MeshMaterial3d(material_gray.clone()),
-    ));
-    let shape = Cuboid::new(3.0, 2.0, 1.0);
-    commands.spawn((
-        Name::new("Cube"),
-        Mesh3d(meshes.add(shape)),
-        RigidBody::Static,
-        Collider::from(shape),
-        Transform::from_xyz(0.0, 1.0, 0.0),
-        MeshMaterial3d(material_gray.clone()),
-    ));
-    let shape = Cuboid::new(1.0, 2.0, 3.0);
-    commands.spawn((
-        Name::new("Cube"),
-        Mesh3d(meshes.add(shape)),
-        RigidBody::Static,
-        Collider::from(shape),
-        Transform::from_xyz(-4.0, 1.0, 5.0),
+        Collider::cylinder(25.0, 0.2),
+        Mesh3d(meshes.add(Cylinder::new(25.0, 0.2))),
         MeshMaterial3d(material_gray.clone()),
     ));
 
-    let shape = Cuboid::new(10.0, 1.0, 10.0);
+    let ball_scales = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0];
+    for (i, &scale) in ball_scales.iter().enumerate() {
+        commands.spawn((
+            Name::new(format!("Ball {}", i + 1)),
+            RigidBody::Static,
+            Collider::sphere(1.0),
+            Mesh3d(meshes.add(Sphere::new(1.0))),
+            Transform::from_xyz(-20.0 + i as f32 * 5.0, 0.0, 5.0 + i as f32)
+                .with_scale(Vec3::splat(scale)),
+            MeshMaterial3d(material_red.clone()),
+        ));
+    }
+
     commands.spawn((
         Name::new("Cube"),
-        Mesh3d(meshes.add(shape)),
         RigidBody::Static,
-        Collider::from(shape),
-        Transform::from_xyz(10.0, 3.0, 3.0),
+        Collider::cuboid(10.0, 1.0, 10.0),
+        Mesh3d(meshes.add(Cuboid::new(10.0, 1.0, 10.0))),
+        Transform::from_xyz(-10.0, 3.0, -10.0),
         MeshMaterial3d(material_red.clone()),
     ));
+
+    commands.spawn((
+        Name::new("RotatedCube"),
+        RigidBody::Static,
+        Collider::cuboid(3.0, 1.0, 3.0),
+        Mesh3d(meshes.add(Cuboid::new(3.0, 1.0, 3.0))),
+        Transform::from_xyz(2.0, 0.5, -2.0)
+            .with_rotation(Quat::from_rotation_y(45.0_f32.to_radians())),
+        MeshMaterial3d(material_red.clone()),
+    ));
+
     commands.spawn((
         DirectionalLight {
             shadows_enabled: true,
@@ -80,7 +85,7 @@ fn setup(
     ));
     commands.spawn((
         Camera3d::default(),
-        Transform::from_xyz(10.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Transform::from_xyz(30.0, 30.0, 30.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
     commands.spawn((

--- a/examples/examples/from_rapier_collider.rs
+++ b/examples/examples/from_rapier_collider.rs
@@ -39,7 +39,7 @@ fn setup(
     commands.spawn((
         Name::new("Ground"),
         RigidBody::Fixed,
-        Collider::cuboid(50.0, 0.1, 50.0),
+        Collider::cuboid(25.0, 0.05, 25.0),
         Mesh3d(meshes.add(Cuboid::new(50.0, 0.1, 50.0))),
         MeshMaterial3d(material_gray.clone()),
     ));
@@ -47,7 +47,7 @@ fn setup(
     commands.spawn((
         Name::new("Cube"),
         RigidBody::Fixed,
-        Collider::cuboid(3.0, 2.0, 1.0),
+        Collider::cuboid(1.5, 1.0, 0.5),
         Mesh3d(meshes.add(Cuboid::new(3.0, 2.0, 1.0))),
         Transform::from_xyz(0.0, 1.0, 0.0),
         MeshMaterial3d(material_gray.clone()),
@@ -56,7 +56,7 @@ fn setup(
     commands.spawn((
         Name::new("Cube"),
         RigidBody::Fixed,
-        Collider::cuboid(1.0, 2.0, 3.0),
+        Collider::cuboid(0.5, 1.0, 1.5),
         Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 3.0))),
         Transform::from_xyz(-4.0, 1.0, 5.0),
         MeshMaterial3d(material_gray.clone()),
@@ -65,7 +65,7 @@ fn setup(
     commands.spawn((
         Name::new("Cube"),
         RigidBody::Fixed,
-        Collider::cuboid(10.0, 1.0, 10.0),
+        Collider::cuboid(5.0, 0.5, 5.0),
         Mesh3d(meshes.add(Cuboid::new(10.0, 1.0, 10.0))),
         Transform::from_xyz(10.0, 3.0, 3.0),
         MeshMaterial3d(material_red.clone()),

--- a/examples/examples/from_rapier_collider.rs
+++ b/examples/examples/from_rapier_collider.rs
@@ -1,0 +1,119 @@
+//! A test scene that only uses primitive shapes.
+
+use bevy::{
+    color::palettes::tailwind,
+    input::common_conditions::input_just_pressed,
+    prelude::*,
+    remote::{RemotePlugin, http::RemoteHttpPlugin},
+};
+use bevy_rapier3d::prelude::*;
+use bevy_rerecast::{debug::DetailNavmeshGizmo, prelude::*};
+use rapier_rerecast::prelude::*;
+
+fn main() -> AppExit {
+    App::new()
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            file_path: "../assets".to_string(),
+            ..default()
+        }))
+        .add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
+        .add_plugins((RemotePlugin::default(), RemoteHttpPlugin::default()))
+        .add_plugins((NavmeshPlugins::default(), RapierBackendPlugin::default()))
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            generate_navmesh.run_if(input_just_pressed(KeyCode::Space)),
+        )
+        .add_observer(configure_camera)
+        .run()
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let material_gray = materials.add(Color::from(tailwind::GRAY_300));
+    let material_red = materials.add(Color::from(tailwind::RED_500));
+
+    commands.spawn((
+        Name::new("Ground"),
+        RigidBody::Fixed,
+        Collider::cuboid(50.0, 0.1, 50.0),
+        Mesh3d(meshes.add(Cuboid::new(50.0, 0.1, 50.0))),
+        MeshMaterial3d(material_gray.clone()),
+    ));
+
+    commands.spawn((
+        Name::new("Cube"),
+        RigidBody::Fixed,
+        Collider::cuboid(3.0, 2.0, 1.0),
+        Mesh3d(meshes.add(Cuboid::new(3.0, 2.0, 1.0))),
+        Transform::from_xyz(0.0, 1.0, 0.0),
+        MeshMaterial3d(material_gray.clone()),
+    ));
+
+    commands.spawn((
+        Name::new("Cube"),
+        RigidBody::Fixed,
+        Collider::cuboid(1.0, 2.0, 3.0),
+        Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 3.0))),
+        Transform::from_xyz(-4.0, 1.0, 5.0),
+        MeshMaterial3d(material_gray.clone()),
+    ));
+
+    commands.spawn((
+        Name::new("Cube"),
+        RigidBody::Fixed,
+        Collider::cuboid(10.0, 1.0, 10.0),
+        Mesh3d(meshes.add(Cuboid::new(10.0, 1.0, 10.0))),
+        Transform::from_xyz(10.0, 3.0, 3.0),
+        MeshMaterial3d(material_red.clone()),
+    ));
+
+    commands.spawn((
+        DirectionalLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::default().looking_to(Vec3::new(0.5, -1.0, 0.3), Vec3::Y),
+    ));
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(10.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    commands.spawn((
+        Text::new("Press space to generate navmesh"),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+    ));
+}
+
+#[derive(Resource)]
+#[allow(dead_code)]
+struct NavmeshHandle(Handle<Navmesh>);
+
+fn generate_navmesh(mut generator: NavmeshGenerator, mut commands: Commands) {
+    let settings = NavmeshSettings::default();
+    let navmesh = generator.generate(settings);
+    commands.spawn(DetailNavmeshGizmo::new(&navmesh));
+    commands.insert_resource(NavmeshHandle(navmesh));
+}
+
+fn configure_camera(
+    trigger: On<Add, Camera>,
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+) {
+    commands.entity(trigger.entity).insert(EnvironmentMapLight {
+        diffuse_map: asset_server.load("environment_maps/voortrekker_interior_1k_diffuse.ktx2"),
+        specular_map: asset_server.load("environment_maps/voortrekker_interior_1k_specular.ktx2"),
+        intensity: 2000.0,
+        ..default()
+    });
+}

--- a/examples/examples/from_rapier_collider.rs
+++ b/examples/examples/from_rapier_collider.rs
@@ -84,7 +84,7 @@ fn setup(
     ));
 
     commands.spawn((
-        Text::new("Press space to generate navmesh"),
+        Text::new("Press space to generate navmesh from rapier colliders"),
         Node {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),

--- a/examples/examples/from_rapier_collider.rs
+++ b/examples/examples/from_rapier_collider.rs
@@ -39,35 +39,40 @@ fn setup(
     commands.spawn((
         Name::new("Ground"),
         RigidBody::Fixed,
-        Collider::cuboid(25.0, 0.05, 25.0),
-        Mesh3d(meshes.add(Cuboid::new(50.0, 0.1, 50.0))),
+        Collider::cylinder(0.1, 25.0),
+        Mesh3d(meshes.add(Cylinder::new(25.0, 0.2))),
         MeshMaterial3d(material_gray.clone()),
     ));
 
-    commands.spawn((
-        Name::new("Cube"),
-        RigidBody::Fixed,
-        Collider::cuboid(1.5, 1.0, 0.5),
-        Mesh3d(meshes.add(Cuboid::new(3.0, 2.0, 1.0))),
-        Transform::from_xyz(0.0, 1.0, 0.0),
-        MeshMaterial3d(material_gray.clone()),
-    ));
-
-    commands.spawn((
-        Name::new("Cube"),
-        RigidBody::Fixed,
-        Collider::cuboid(0.5, 1.0, 1.5),
-        Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 3.0))),
-        Transform::from_xyz(-4.0, 1.0, 5.0),
-        MeshMaterial3d(material_gray.clone()),
-    ));
+    let ball_scales = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0];
+    for (i, &scale) in ball_scales.iter().enumerate() {
+        commands.spawn((
+            Name::new(format!("Ball {}", i + 1)),
+            RigidBody::Fixed,
+            Collider::ball(1.0),
+            Mesh3d(meshes.add(Sphere::new(1.0))),
+            Transform::from_xyz(-20.0 + i as f32 * 5.0, 0.0, 5.0 + i as f32)
+                .with_scale(Vec3::splat(scale)),
+            MeshMaterial3d(material_red.clone()),
+        ));
+    }
 
     commands.spawn((
         Name::new("Cube"),
         RigidBody::Fixed,
         Collider::cuboid(5.0, 0.5, 5.0),
         Mesh3d(meshes.add(Cuboid::new(10.0, 1.0, 10.0))),
-        Transform::from_xyz(10.0, 3.0, 3.0),
+        Transform::from_xyz(-10.0, 3.0, -10.0),
+        MeshMaterial3d(material_red.clone()),
+    ));
+
+    commands.spawn((
+        Name::new("RotatedCube"),
+        RigidBody::Fixed,
+        Collider::cuboid(1.5, 0.5, 1.5),
+        Mesh3d(meshes.add(Cuboid::new(3.0, 1.0, 3.0))),
+        Transform::from_xyz(2.0, 0.5, -2.0)
+            .with_rotation(Quat::from_rotation_y(45.0_f32.to_radians())),
         MeshMaterial3d(material_red.clone()),
     ));
 
@@ -80,7 +85,7 @@ fn setup(
     ));
     commands.spawn((
         Camera3d::default(),
-        Transform::from_xyz(10.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Transform::from_xyz(30.0, 30.0, 30.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
     commands.spawn((

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,16 @@ If you've disabled the default features of `bevy_rerecast`, make sure to enable 
 
 ### Backends
 
-The recommended way to use the navmesh generator is with a physics engine backend. That way, the generated navmesh will match the physics engine's collision geometry. Currently, the only supported physics engine is [Avian](https://github.com/avianphysics/avian). To use its backend, add the `avian_rerecast` crate to your project:
+The recommended way to use the navmesh generator is with a physics engine backend. That way, the generated navmesh will match the physics engine's collision geometry.
+Currently, the only supported physics engines are:
+- [Avian](https://github.com/avianphysics/avian)
+- [Bevy Rapier](https://github.com/dimforge/bevy_rapier)
+
+Creating your own backend is *very* easy. Take a look at the implementation of the [`AvianBackendPlugin`] as an example.
+
+#### Avian Backend
+
+To use the backend, add the `avian_rerecast` crate to your project:
 
 ```bash
 cargo add avian_rerecast
@@ -161,13 +170,32 @@ use avian_rerecast::prelude::*;
 
 App::new()
     .add_plugins(DefaultPlugins)
-    .add_plugins(NavmeshPlugins::default())
-    .add_plugins(AvianBackendPlugin::default());
+    .add_plugins((NavmeshPlugins::default(), AvianBackendPlugin::default()));
 ```
 
 The avian backend will consider colliders that are part of a static rigid body as obstacles.
 
-Creating your own backend is *very* easy. Take a look at the implementation of the [`AvianBackendPlugin`] as an example.
+#### Bevy Rapier Backend
+
+To use the backend, add the `rapier_rerecast` crate to your project:
+
+```bash
+cargo add rapier_rerecast
+```
+
+and then register its backend:
+
+```rust,ignore
+use bevy::prelude::*;
+use bevy_rerecast::prelude::*;
+use rapier_rerecast::prelude::*;
+
+App::new()
+    .add_plugins(DefaultPlugins)
+    .add_plugins((NavmeshPlugins::default(), RapierBackendPlugin::default()));
+```
+
+The bevy rapier backend will consider colliders that are part of a static rigid body as obstacles.
 
 ### Pathfinding
 


### PR DESCRIPTION
Since *avian3d* and *bevy_rapier* are pretty similar, *rapier_rerecast* turned out to be a pretty much a copy past of *avian_rerecast* with minor differences:
1. Rapier doesn't have `ColliderOf`, so I have to find the body manually in `collider_backend`.
2. In `impl ColliderToTriMesh for Collider`, I have to scale the collider by 0.5, otherwise it is too big.

I also took the liberty of adding the new backend to readme.

There is also a copy-past example for *rapier_rerecast* based on the avian example, and here is side-by-side comparison:
<img width="1835" height="1117" alt="Screenshot-2026-04-16T16:29:51,757316176+07:00" src="https://github.com/user-attachments/assets/18daa0eb-b22b-47e3-b5f9-72b423885264" />
